### PR TITLE
Make 'output' optional and fix 'matchParent' option ignoring rules without parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Type: `RegExp`
 If a RegExp then selectors matching this regular expression will be added to the output file.
 
 #### options.pattern.matchParent
-Type: `Boolean`  
+Type: `Boolean`
 Default: `false`
 
 If `true` then a declaration's parent media node will be matched along with the declaration itself.
@@ -80,10 +80,10 @@ Yields:
 #### options.output
 Type: `String`
 
-The new CSS file to copy the matching rulesets to.
+Optional new CSS file to copy the matching rulesets to.
 
 #### options.remove
-Type: `Boolean`  
+Type: `Boolean`
 Default value: `true`
 
 Whether or not to remove the matching rulesets from the original stylesheet.
@@ -94,7 +94,7 @@ Type: `RegExp`
 `@media` rulesets matching this regular expression will be copied into the new stylesheet
 
 #### options.mediaPatternUnwrap
-Type: `Boolean`  
+Type: `Boolean`
 Default value: `false`
 
 If `true`, only the child declarations of a matched `@media` rule will be extracted.
@@ -154,8 +154,8 @@ grunt.initConfig({
       files: {
         '<%= pkg.theme.path %>/style.css': '<%= pkg.theme.path %>/style.css'
       }
-    },
-  },
+    }
+  }
 });
 ```
 
@@ -164,6 +164,10 @@ grunt.initConfig({
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 
 ## Release History
+
+* 2014-02-26 v0.3.0
+    * Made 'output' optional (default false).
+    * Fixed 'matchParent' option ignoring rules without parent.
 
 * 2014-02-25 v0.2.0
     * Add option to match parent nodes of declarations.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-split-styles",
   "description": "Split a CSS file based on selectors. Useful for old IE stylesheets",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "homepage": "https://github.com/dbisso/grunt-split-style",
   "author": {
     "name": "Dan Bissonnet",

--- a/tasks/split_styles.js
+++ b/tasks/split_styles.js
@@ -19,6 +19,7 @@ module.exports = function(grunt) {
 			remove: true, // Should we strip the matched rules from the src style sheet?
 			mediaPattern: false, // RegExp to match @media rules with
 			mediaPatternUnwrap: false, // Extract the rules from a matched @media block
+			output: false // output file 'false' by default
 		});
 
 		var pattern = {};
@@ -36,28 +37,25 @@ module.exports = function(grunt) {
 			if ( pattern.match ) {
 				css.eachRule(function (rule) {
 						var parent;
-
 						if ( rule.selector.match(pattern.match) ) {
-								if ( options.remove ) {
-									rule.removeSelf();
-								}
+							if ( options.remove ) {
+								rule.removeSelf();
+							}
+							if ( pattern.matchParent ) {
+								parent = rule.parent.clone();
 
-								if ( pattern.matchParent ) {
-									parent = rule.parent.clone();
-
-									if ( 'media' === parent.name ) {
-										parent.eachRule(function (childRule) {
-											childRule.removeSelf();
-										});
-
-										parent.append(rule);
-										newCSS.append(parent);
-									} else {
-										newCSS.append(rule);
-									}
+								if ( 'media' === parent.name ) {
+									parent.eachRule(function (childRule) {
+										childRule.removeSelf();
+									});
+									parent.append(rule);
+									newCSS.append(parent);
 								} else {
 									newCSS.append(rule);
 								}
+							} else {
+								newCSS.append(rule);
+							}
 						}
 				});
 			}
@@ -65,11 +63,9 @@ module.exports = function(grunt) {
 			if (options.mediaPattern) {
 				css.eachAtRule(function (atRule) {
 					if ( 'media' === atRule.name && atRule.params.match(options.mediaPattern) ) {
-
 						if ( options.remove ) {
 							atRule.removeSelf();
 						}
-
 						if ( options.mediaPatternUnwrap ) {
 							atRule.eachRule(function (rule) {
 								newCSS.append(rule);

--- a/tasks/split_styles.js
+++ b/tasks/split_styles.js
@@ -52,6 +52,8 @@ module.exports = function(grunt) {
 
 										parent.append(rule);
 										newCSS.append(parent);
+									} else {
+										newCSS.append(rule);
 									}
 								} else {
 									newCSS.append(rule);
@@ -102,7 +104,7 @@ module.exports = function(grunt) {
 				// Run the postprocessor
 				output = processor.process(css, processOptions);
 
-				if ( output.map && output.map.length > 0 ) {
+				if ( options.output && output.map && output.map.length > 0 ) {
 					grunt.log.writeln('Sourcemap "' + options.output + '" created.');
 					grunt.file.write( f.dest + '.map' , output.map);
 				}
@@ -111,13 +113,17 @@ module.exports = function(grunt) {
 			});
 
 			// Write the newly split file.
-			grunt.file.write(options.output, newCSS);
+			if(options.output) {
+				grunt.file.write(options.output, newCSS);
+			}
 
 			// Write the destination file
 			grunt.file.write(f.dest, src);
 
 			// Print a success message.
-			grunt.log.writeln('File "' + options.output + '" created.');
+			if(options.output) {
+				grunt.log.writeln('File "' + options.output + '" created.');
+			}
 			grunt.log.writeln('File "' + f.dest + '" created.');
 		});
 	});


### PR DESCRIPTION
https://github.com/dbisso/grunt-split-styles/issues/5
https://github.com/dbisso/grunt-split-styles/issues/6
